### PR TITLE
Rewrite of existing theme and fix for card background and Sorry!

### DIFF
--- a/themes/nord.yaml
+++ b/themes/nord.yaml
@@ -21,59 +21,61 @@ nord:
   nord14: "#a3be8c"  # Nord14 - green
   nord15: "#b48ead"  # Nord15 - purple
 
-  primary-color: "var(--nord9)"
-  light-primary-color: "var(--nord0)"
-  primary-background-color: "var(--nord0)"
-  secondary-background-color: "var(--nord0)"
-  divider-color: "var(--nord0)"
-  paper-grey-50: "var(--nord9)"
-  paper-grey-200: "var(--nord0)"
+  ha-card-border-radius: 2px
+  ha-card-box-shadow: "1px 1px 2px 0px rgba(0,0,0,0.3)"
+
+  primary-color: "var(--nord4)"
+  light-primary-color: "var(--nord6)"
+  graph-color: var(--primary-color)
+  primary-background-color: "var(--nord3)"
+  secondary-background-color: var(--primary-background-color)
+  divider-color: "var(--nord1)"
+  disabled-color: "var(--nord10)"
+
   primary-text-color: "var(--nord6)"
-  secondary-text-color: "var(--nord6)"
-  disabled-text-color: "grey"
-  light-disabled-text-color: "var(--nord2)"
-  dark-primary-color: "var(--nord9)"
+  secondary-text-color: var(--primary-color)
+  text-primary-color: var(--primary-text-color)
+  disabled-text-color: "var(--nord11)"
 
-  # Interface
-  ha-card-border-radius: "0px"
-  primary-font-family: "Roboto Condensed, Roboto, system-ui"
+  sidebar-icon-color: var(--primary-color)
+  sidebar-text-color: var(--primary-text-color)
+  sidebar-background-color: "var(--nord3)"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: var(--light-primary-color)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
 
-  # Paper
+  state-icon-color: var(--primary-color)
+  state-icon-active-color: "var(--nord9)"
+  state-icon-unavailable-color: var(--disabled-text-color)
+
+  paper-slider-knob-color: var(--primary-color)
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: var(--paper-slider-knob-color)
+  paper-slider-secondary-color: var(--light-primary-color)
+  label-badge-background-color: var(--divider-color)
+  label-badge-text-color: var(--primary-text-color)
+  label-badge-red: var(--light-primary-color)
+
   paper-card-background-color: "var(--nord3)"
-  paper-card-header-color: "var(--nord9)"
-  paper-listbox-background-color: "var(--nord1)"
-  paper-listbox-color: "var(--nord9)"
-  paper-item-selected_-_background-color: "var(--nord0)"
-  paper-item-icon-color: "var(--nord6)"
-  paper-item-icon_-_color: "var(--nord6)"
-  paper-item-icon-active-color: "var(--nord9)"
+  paper-listbox-background-color: var(--primary-background-color)
 
-  # Label-badge
-  label-badge-text-color: "var(--nord6)"
-  label-badge-background-color: "var(--nord3)"
-  label-badge-red: "var(--nord11)"
+  paper-toggle-button-checked-button-color: var(--primary-color)
+  paper-toggle-button-checked-bar-color: var(--light-primary-color)
+  paper-toggle-button-unchecked-button-color: var(--disabled-color)
+  paper-toggle-button-unchecked-bar-color: "var(--nord7)"
 
-  # Slider
-  paper-slider-active-color: "var(--nord9)"
-  paper-slider-secondary-color: "var(--nord9)"
-  paper-slider-knob-color: "var(--nord9)"
-  paper-slider-knob-start-color: "var(--nord9)"
-  paper-slider-pin-color: "var(--nord9)"
+  switch-checked-color: var(--paper-toggle-button-checked-button-color)
+  switch-unchecked-button-color: var(--paper-toggle-button-unchecked-button-color)
+  switch-unchecked-color: var(--paper-toggle-button-unchecked-bar-color)
+  switch-unchecked-track-color: var(--paper-toggle-button-unchecked-bar-color)
 
-  # Toggle
-  paper-toggle-button-unchecked-bar-color: "var(--nord9)"
-  paper-toggle-button-unchecked-button-color: "var(--nord9)"
-  paper-toggle-button-unchecked-ink-color: "var(--nord9)"
-  paper-toggle-button-checked-bar-color: "var(--nord9)"
-  paper-toggle-button-checked-button-color: "var(--nord9)"
+  table-row-background-color: var(--divider-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  card-background-color: var(--primary-background-color)
 
-  # Switch
-  switch-unchecked-track-color: "var(--nord6)"
-  switch-unchecked-color: "var(--nord6)"
-  switch-checked-track-color: "var(--nord9)"
-  switch-checked-color: "var(--nord9)"
+  app-header-background-color: var(--nord2)
 
-  # Font Settings
   paper-font-common-base_-_font-family: "var(--primary-font-family)"
   paper-font-common-code_-_font-family: "var(--primary-font-family)"
   paper-font-body1_-_font-family: "var(--primary-font-family)"
@@ -81,9 +83,4 @@ nord:
   paper-font-headline_-_font-family: "var(--primary-font-family)"
   paper-font-caption_-_font-family: "var(--primary-font-family)"
   paper-font-title_-_font-family: "var(--primary-font-family)"
-  ha-card-header-font-family: "var(--primary-font-family)"
-  ha-card-header-color: "var(--nord6)"
-
-  # Other
-  sidebar-icon-color: "var(--nord6)"
-  sidebar-background-color: "var(--nord1)"
+  paper-item-icon-active-color: var(--nord13)


### PR DESCRIPTION
First up huge apologies for:

1. My last pull request, it broke things that I didn't see because of browser caching
2. Again the mess of this PR
3. Breaking peoples Nord theme.

I should have tested tested and tested my last PR before submitting it.

This pull request is a complete rewrite based on https://github.com/awolkers/home-assistant-themes. It taught me a lot about how HA does it's theming and to be honest it's short falls. I've spent a good few hours trying to fix the old implementation but actually ended up making things worse. This new version isn't without faults but it's less broken than my last PR.

There are two options here:

1. Test and accept this PR
2. Revert my last PR

Here are some screenshots after uninstalling and reinstalling my version:

![image](https://user-images.githubusercontent.com/242104/88409867-76012e00-cdcd-11ea-96be-831b9c7c81b6.png)

There are two lights currently not working in the Bedroom because my wife keeps turning them off at the switches, so they show up red. When the lights are on they show up yellow.

![image](https://user-images.githubusercontent.com/242104/88409895-80232c80-cdcd-11ea-8271-10961f49e03d.png)

![image](https://user-images.githubusercontent.com/242104/88410196-f32ca300-cdcd-11ea-8ad4-800e91dcdec9.png)

Not both the button and profile icon are hard to read this is because of what HA assigns to the element I think it can be fixed though. The white bits in the bottom left are from the screenshot software, it's not present on the real thing.