### PR TITLE
Fix unreadable code editor

### DIFF
--- a/themes/nord.yaml
+++ b/themes/nord.yaml
@@ -28,6 +28,7 @@ nord:
   graph-color: "var(--primary-color)"
   primary-background-color: "var(--nord0)"
   secondary-background-color: "var(--nord3)"
+  code-editor-background-color: "var(--nord0)"
   divider-color: "var(--nord3)"
   disabled-color: grey
 


### PR DESCRIPTION
YAML editor was unreadable due to light text on white background. This changes the editor background color to `nord-0`.

Fixes #19.